### PR TITLE
fix: add missing wit fetch

### DIFF
--- a/examples/hello/Makefile
+++ b/examples/hello/Makefile
@@ -1,3 +1,14 @@
+.PHONY: fetch
+fetch:
+	@echo "Fetching wit dependencies"
+	@wkg wit fetch
+
 .PHONY: build
-build:
-	componentize-go --world hello build --output build/hello.wasm
+build: fetch
+	@echo "Building component"
+	@componentize-go --world hello build --output build/hello.wasm
+
+.PHONY: clean
+clean:
+	@echo "Cleaning files"
+	@rm -rf build wit/deps


### PR DESCRIPTION
# Description
- Add missing wit dependencies fetch step in example build
  - Puts dependencies in the `hello/wit/deps` folder for `componentize-go` to pick up
- #3 