### PR TITLE
ci: add release workflow to build and publish example wasm artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,8 @@ jobs:
           path: artifacts
           merge-multiple: true
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: artifacts/*.wasm
-          generate_release_notes: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" artifacts/*.wasm \
+            --generate-notes


### PR DESCRIPTION
Triggers on tag pushes (v*) or manual dispatch. Builds all three example
functions using the same toolchain as CI (wash + componentize-go), then
creates a GitHub Release with the compiled .wasm files attached.

https://claude.ai/code/session_01RpfvRFnFKCwnMBevzSx9i4