### PR TITLE
Clean up wasihttp and export_wasi_http_handler for readability

### DIFF
--- a/p3/gen/export_wasi_http_handler/handler.go
+++ b/p3/gen/export_wasi_http_handler/handler.go
@@ -16,8 +16,8 @@ func SetHttpHandler(h http.HandlerFunc) {
 func Handle(request *httpTypes.Request) witTypes.Result[*httpTypes.Response, httpTypes.ErrorCode] {
 	req, err := newHttpRequest(request)
 	if err != nil {
-		Err := httpTypes.MakeErrorCodeInternalError(witTypes.Some(err.Error()))
-		return witTypes.Err[*httpTypes.Response](Err)
+		errCode := httpTypes.MakeErrorCodeInternalError(witTypes.Some(err.Error()))
+		return witTypes.Err[*httpTypes.Response](errCode)
 	}
 
 	if req.Body != nil {

--- a/p3/gen/export_wasi_http_handler/request.go
+++ b/p3/gen/export_wasi_http_handler/request.go
@@ -29,7 +29,7 @@ func newHttpRequest(request *httpTypes.Request) (*http.Request, error) {
 	headers := request.GetHeaders()
 	httpHeaders := http.Header{}
 	for _, vals := range headers.CopyAll() {
-		httpHeaders.Set(vals.F0, string(vals.F1))
+		httpHeaders.Add(vals.F0, string(vals.F1))
 	}
 	headers.Drop()
 

--- a/p3/gen/export_wasi_http_handler/response.go
+++ b/p3/gen/export_wasi_http_handler/response.go
@@ -25,7 +25,7 @@ type responseHandler struct {
 
 	httpHeaders http.Header
 
-	headerOnce sync.Once
+	flushOnce sync.Once
 	statusCode int
 }
 
@@ -36,7 +36,7 @@ func (r *responseHandler) Header() http.Header {
 }
 
 func (r *responseHandler) Write(b []byte) (int, error) {
-	r.headerOnce.Do(r.flush)
+	r.flushOnce.Do(r.flush)
 	if r.bodyWriter == nil {
 		return 0, errors.New("response body stream is nil")
 	}
@@ -44,14 +44,14 @@ func (r *responseHandler) Write(b []byte) (int, error) {
 }
 
 func (r *responseHandler) WriteHeader(statusCode int) {
-	r.headerOnce.Do(func() {
+	r.flushOnce.Do(func() {
 		r.statusCode = statusCode
 		r.flush()
 	})
 }
 
 func (r *responseHandler) Close() error {
-	r.headerOnce.Do(r.flush)
+	r.flushOnce.Do(r.flush)
 	if r.bodyWriter != nil {
 		return r.bodyWriter.Close()
 	}
@@ -61,7 +61,8 @@ func (r *responseHandler) Close() error {
 func (r *responseHandler) flush() {
 	wasiHeaders, err := internalhttp.MapHttpHeaders(r.httpHeaders)
 	if err != nil {
-		// TODO: handle error
+		errCode := httpTypes.MakeErrorCodeInternalError(witTypes.Some(err.Error()))
+		r.responseChan <- witTypes.Err[*httpTypes.Response](errCode)
 		return
 	}
 

--- a/p3/net/wasihttp/roundtripper.go
+++ b/p3/net/wasihttp/roundtripper.go
@@ -20,9 +20,8 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// We don't need the body-consumed notification; drop it to avoid blocking.
 	futureRead.Drop()
 
-	// Write the body concurrently with Send: SubtaskWait yields to the Go
-	// scheduler, which lets this goroutine write body data into the stream
-	// that the runtime opened when Send started.
+	// Write the body concurrently: the goroutine streams request body data
+	// into the WASI stream while Send blocks waiting for the response.
 	go finish()
 
 	// send request


### PR DESCRIPTION
- roundtripper.go: remove misleading "SubtaskWait" from comment
- handler.go: rename Err -> errCode (unexported, clearer type intent)
- request.go: use Add() instead of Set() for headers to preserve duplicates
- response.go: rename headerOnce -> flushOnce; propagate header-mapping
  errors through the response channel instead of silently discarding them

https://claude.ai/code/session_019DTnJLqu5H6C8tRKV4DAff