### PR TITLE
Fix TLS errors in wasihttp RoundTripper by populating authority correctly

### DIFF
--- a/net/wasihttp/errors.go
+++ b/net/wasihttp/errors.go
@@ -53,3 +53,18 @@ var (
 	// ErrConfigurationError is returned when the HTTP handler or proxy is misconfigured.
 	ErrConfigurationError = errors.New("configuration error")
 )
+
+// Sentinel errors for WASI resource-state conditions. These indicate a
+// programming bug in the SDK (a handle was consumed twice) rather than a
+// network or TLS failure.
+var (
+	// ErrOutgoingBodyTaken is returned when the outgoing request body has
+	// already been taken.
+	ErrOutgoingBodyTaken = errors.New("outgoing request body already taken")
+	// ErrFutureResponseConsumed is returned when the future incoming response
+	// has already been consumed.
+	ErrFutureResponseConsumed = errors.New("future incoming response already consumed")
+	// ErrIncomingResponseConsumed is returned when the incoming response body
+	// has already been consumed.
+	ErrIncomingResponseConsumed = errors.New("incoming response already consumed")
+)

--- a/net/wasihttp/request.go
+++ b/net/wasihttp/request.go
@@ -13,7 +13,15 @@ import (
 func parseHttpRequest(req *http.Request) *types.OutgoingRequest {
 	resp := newOutgoingRequest(req.Header)
 
-	resp.SetAuthority(witTypes.Some(req.Host))
+	// req.Host may be empty on client requests; per net/http, the transport
+	// falls back to req.URL.Host in that case. The authority is also used by
+	// the WASI host for TLS SNI, so an empty value causes TLS handshake
+	// failures (certificate/hostname mismatch) against HTTPS endpoints.
+	host := req.Host
+	if host == "" {
+		host = req.URL.Host
+	}
+	resp.SetAuthority(witTypes.Some(host))
 	resp.SetMethod(mapMethod(req.Method))
 	resp.SetPathWithQuery(witTypes.Some(req.URL.RequestURI()))
 	resp.SetScheme(mapUrlScheme(req.URL))
@@ -24,6 +32,12 @@ func parseHttpRequest(req *http.Request) *types.OutgoingRequest {
 func newOutgoingRequest(h http.Header) *types.OutgoingRequest {
 	outHeaders := types.MakeFields()
 	for k, v := range h {
+		// The Host header is carried by SetAuthority on the outgoing request.
+		// Forwarding it as a field can conflict with the authority used for
+		// TLS SNI and is rejected by some WASI HTTP implementations.
+		if http.CanonicalHeaderKey(k) == "Host" {
+			continue
+		}
 		for _, vs := range v {
 			outHeaders.Append(k, []uint8(vs))
 		}

--- a/net/wasihttp/request.go
+++ b/net/wasihttp/request.go
@@ -13,10 +13,8 @@ import (
 func parseHttpRequest(req *http.Request) *types.OutgoingRequest {
 	resp := newOutgoingRequest(req.Header)
 
-	// req.Host may be empty on client requests; per net/http, the transport
-	// falls back to req.URL.Host in that case. The authority is also used by
-	// the WASI host for TLS SNI, so an empty value causes TLS handshake
-	// failures (certificate/hostname mismatch) against HTTPS endpoints.
+	// req.Host may be empty on client requests; fall back to req.URL.Host
+	// so the WASI host has a valid authority for TLS SNI.
 	host := req.Host
 	if host == "" {
 		host = req.URL.Host

--- a/net/wasihttp/request.go
+++ b/net/wasihttp/request.go
@@ -20,16 +20,16 @@ func parseHttpRequest(req *http.Request) (*types.OutgoingRequest, error) {
 	if host == "" {
 		host = req.URL.Host
 	}
-	if r := resp.SetAuthority(witTypes.Some(host)); r.IsErr() {
+	if resp.SetAuthority(witTypes.Some(host)).IsErr() {
 		return nil, fmt.Errorf("invalid request authority %q", host)
 	}
-	if r := resp.SetMethod(mapMethod(req.Method)); r.IsErr() {
+	if resp.SetMethod(mapMethod(req.Method)).IsErr() {
 		return nil, fmt.Errorf("invalid request method %q", req.Method)
 	}
-	if r := resp.SetPathWithQuery(witTypes.Some(req.URL.RequestURI())); r.IsErr() {
+	if resp.SetPathWithQuery(witTypes.Some(req.URL.RequestURI())).IsErr() {
 		return nil, fmt.Errorf("invalid request path %q", req.URL.RequestURI())
 	}
-	if r := resp.SetScheme(mapUrlScheme(req.URL)); r.IsErr() {
+	if resp.SetScheme(mapUrlScheme(req.URL)).IsErr() {
 		return nil, fmt.Errorf("invalid request scheme %q", req.URL.Scheme)
 	}
 

--- a/net/wasihttp/request.go
+++ b/net/wasihttp/request.go
@@ -32,12 +32,6 @@ func parseHttpRequest(req *http.Request) *types.OutgoingRequest {
 func newOutgoingRequest(h http.Header) *types.OutgoingRequest {
 	outHeaders := types.MakeFields()
 	for k, v := range h {
-		// The Host header is carried by SetAuthority on the outgoing request.
-		// Forwarding it as a field can conflict with the authority used for
-		// TLS SNI and is rejected by some WASI HTTP implementations.
-		if http.CanonicalHeaderKey(k) == "Host" {
-			continue
-		}
 		for _, vs := range v {
 			outHeaders.Append(k, []uint8(vs))
 		}

--- a/net/wasihttp/request.go
+++ b/net/wasihttp/request.go
@@ -1,6 +1,7 @@
 package wasihttp
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -10,7 +11,7 @@ import (
 	witTypes "go.bytecodealliance.org/pkg/wit/types"
 )
 
-func parseHttpRequest(req *http.Request) *types.OutgoingRequest {
+func parseHttpRequest(req *http.Request) (*types.OutgoingRequest, error) {
 	resp := newOutgoingRequest(req.Header)
 
 	// req.Host may be empty on client requests; fall back to req.URL.Host
@@ -19,12 +20,20 @@ func parseHttpRequest(req *http.Request) *types.OutgoingRequest {
 	if host == "" {
 		host = req.URL.Host
 	}
-	resp.SetAuthority(witTypes.Some(host))
-	resp.SetMethod(mapMethod(req.Method))
-	resp.SetPathWithQuery(witTypes.Some(req.URL.RequestURI()))
-	resp.SetScheme(mapUrlScheme(req.URL))
+	if r := resp.SetAuthority(witTypes.Some(host)); r.IsErr() {
+		return nil, fmt.Errorf("invalid request authority %q", host)
+	}
+	if r := resp.SetMethod(mapMethod(req.Method)); r.IsErr() {
+		return nil, fmt.Errorf("invalid request method %q", req.Method)
+	}
+	if r := resp.SetPathWithQuery(witTypes.Some(req.URL.RequestURI())); r.IsErr() {
+		return nil, fmt.Errorf("invalid request path %q", req.URL.RequestURI())
+	}
+	if r := resp.SetScheme(mapUrlScheme(req.URL)); r.IsErr() {
+		return nil, fmt.Errorf("invalid request scheme %q", req.URL.Scheme)
+	}
 
-	return resp
+	return resp, nil
 }
 
 func newOutgoingRequest(h http.Header) *types.OutgoingRequest {

--- a/net/wasihttp/response.go
+++ b/net/wasihttp/response.go
@@ -13,12 +13,14 @@ import (
 func parseFutureResponse(ctx context.Context, resp *types.FutureIncomingResponse) (*http.Response, error) {
 	optResponse := resp.Get()
 	if optResponse.IsNone() {
-		return nil, errors.New("failed to fetch future response - response is empty")
+		return nil, errors.New("future incoming response not ready")
 	}
 
+	// The outer result signals whether the future has already been consumed;
+	// only the inner result carries the wasi:http error-code.
 	innerResult := optResponse.Some()
 	if innerResult.IsErr() {
-		return nil, errors.New("failed to unwrap future response")
+		return nil, ErrFutureResponseConsumed
 	}
 	innerResponse := innerResult.Ok()
 
@@ -50,7 +52,7 @@ func parseIncomingResponse(ctx context.Context, resp *types.IncomingResponse) (*
 func newResponseBody(ctx context.Context, resp *types.IncomingResponse) (io.ReadCloser, http.Header, error) {
 	bodyRes := resp.Consume()
 	if bodyRes.IsErr() {
-		return nil, nil, errors.New("failed to consume incoming response")
+		return nil, nil, ErrIncomingResponseConsumed
 	}
 	rawBody, trailer, err := httptypes.NewIncomingBodyReader(ctx, bodyRes.Ok())
 	if err != nil {

--- a/net/wasihttp/roundtripper.go
+++ b/net/wasihttp/roundtripper.go
@@ -1,7 +1,6 @@
 package wasihttp
 
 import (
-	"errors"
 	"net/http"
 
 	handler "github.com/jamesstocktonj1/componentize-sdk/gen/wasi_http_outgoing_handler"
@@ -19,7 +18,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// open outgoing request body
 	bodyRes := outRequest.Body()
 	if bodyRes.IsErr() {
-		return nil, errors.New("failed to fetch response body")
+		return nil, ErrOutgoingBodyTaken
 	}
 	body := bodyRes.Ok()
 

--- a/net/wasihttp/roundtripper.go
+++ b/net/wasihttp/roundtripper.go
@@ -13,7 +13,10 @@ var _ http.RoundTripper = (*Transport)(nil)
 
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// parse request
-	outRequest := parseHttpRequest(req)
+	outRequest, err := parseHttpRequest(req)
+	if err != nil {
+		return nil, err
+	}
 
 	// open outgoing request body
 	bodyRes := outRequest.Body()
@@ -30,8 +33,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	futureResp := futureRes.Ok()
 
 	// write request body and trailers
-	err := finishRequestBody(req, body)
-	if err != nil {
+	if err := finishRequestBody(req, body); err != nil {
 		return nil, err
 	}
 

--- a/p3/gen/export_wasi_http_handler/request.go
+++ b/p3/gen/export_wasi_http_handler/request.go
@@ -54,5 +54,5 @@ func newRequestBodyTrailer(request *httpTypes.Request) (io.ReadCloser, http.Head
 	stream, trailersFut := httpTypes.RequestConsumeBody(request, read)
 
 	trailerMap := http.Header{}
-	return internalhttp.NewBodyReader(stream, trailersFut, fut, trailerMap), trailerMap
+	return internalhttp.NewBodyReader(stream, trailersFut, fut, trailerMap, nil), trailerMap
 }

--- a/p3/internal/wasihttp/body.go
+++ b/p3/internal/wasihttp/body.go
@@ -58,21 +58,30 @@ func (w *bodyWriter) Close() error {
 	return w.closeErr
 }
 
+// ErrorCodeMapper maps a wasi:http error-code into a Go error. The internal
+// body reader uses this to surface trailer-read failures without depending on
+// the public net/wasihttp package (which would create an import cycle).
+type ErrorCodeMapper func(httpTypes.ErrorCode) error
+
 // NewBodyReader wraps a WASI stream + trailer futures as an io.ReadCloser.
 // The provided trailerMap will be populated with trailers once the body is
 // fully read. The caller must share the same trailerMap reference with the
 // http.Response.Trailer field so trailers are visible after the body is read.
+// mapErr is used to translate an error-code from the trailer future into a
+// Go error surfaced via Read/Close; if nil, trailer errors are discarded.
 func NewBodyReader(
 	stream *witTypes.StreamReader[uint8],
 	trailersFut *witTypes.FutureReader[witTypes.Result[witTypes.Option[*httpTypes.Fields], httpTypes.ErrorCode]],
 	fut *witTypes.FutureWriter[witTypes.Result[witTypes.Unit, httpTypes.ErrorCode]],
 	trailerMap http.Header,
+	mapErr ErrorCodeMapper,
 ) io.ReadCloser {
 	return &bodyReader{
 		stream:      stream,
 		trailersFut: trailersFut,
 		fut:         fut,
 		trailerMap:  trailerMap,
+		mapErr:      mapErr,
 	}
 }
 
@@ -81,7 +90,9 @@ type bodyReader struct {
 	trailersFut *witTypes.FutureReader[witTypes.Result[witTypes.Option[*httpTypes.Fields], httpTypes.ErrorCode]]
 	fut         *witTypes.FutureWriter[witTypes.Result[witTypes.Unit, httpTypes.ErrorCode]]
 	trailerMap  http.Header
+	mapErr      ErrorCodeMapper
 	headerOnce  sync.Once
+	trailerErr  error
 }
 
 var _ io.ReadCloser = (*bodyReader)(nil)
@@ -91,10 +102,16 @@ func (s *bodyReader) Read(p []byte) (int, error) {
 
 	if s.stream.WriterDropped() {
 		s.headerOnce.Do(s.readTrailers)
-		if n > 0 {
-			return n, io.EOF
+		// Prefer surfacing the runtime error over io.EOF so the caller
+		// doesn't mistake a TLS/transport failure for a clean end of body.
+		err := s.trailerErr
+		if err == nil {
+			err = io.EOF
 		}
-		return 0, io.EOF
+		if n > 0 {
+			return n, err
+		}
+		return 0, err
 	}
 
 	return n, nil
@@ -103,15 +120,19 @@ func (s *bodyReader) Read(p []byte) (int, error) {
 func (s *bodyReader) readTrailers() {
 	s.fut.Write(witTypes.Ok[witTypes.Unit, httpTypes.ErrorCode](witTypes.Unit{}))
 	result := s.trailersFut.Read()
-	if result.IsOk() {
-		opt := result.Ok()
-		if opt.IsSome() {
-			fields := opt.Some()
-			for _, kv := range fields.CopyAll() {
-				s.trailerMap.Add(kv.F0, string(kv.F1))
-			}
-			fields.Drop()
+	if result.IsErr() {
+		if s.mapErr != nil {
+			s.trailerErr = s.mapErr(result.Err())
 		}
+		return
+	}
+	opt := result.Ok()
+	if opt.IsSome() {
+		fields := opt.Some()
+		for _, kv := range fields.CopyAll() {
+			s.trailerMap.Add(kv.F0, string(kv.F1))
+		}
+		fields.Drop()
 	}
 }
 
@@ -122,5 +143,5 @@ func (s *bodyReader) Close() error {
 		s.trailersFut.Drop()
 	})
 	s.stream.Drop()
-	return nil
+	return s.trailerErr
 }

--- a/p3/net/wasihttp/request.go
+++ b/p3/net/wasihttp/request.go
@@ -34,10 +34,10 @@ func parseHttpRequest(req *http.Request) (*httpTypes.Request, *witTypes.FutureRe
 	opts := witTypes.None[*httpTypes.RequestOptions]()
 	res, futureRead := httpTypes.RequestNew(f, someBody, trailerReader, opts)
 
-	if r := res.SetMethod(internalhttp.MapMethodToWasi(req.Method)); r.IsErr() {
+	if res.SetMethod(internalhttp.MapMethodToWasi(req.Method)).IsErr() {
 		return nil, nil, nil, fmt.Errorf("invalid request method %q", req.Method)
 	}
-	if r := res.SetScheme(mapUrlScheme(req.URL)); r.IsErr() {
+	if res.SetScheme(mapUrlScheme(req.URL)).IsErr() {
 		return nil, nil, nil, fmt.Errorf("invalid request scheme %q", req.URL.Scheme)
 	}
 	// req.Host may be empty on client requests; fall back to req.URL.Host
@@ -46,10 +46,10 @@ func parseHttpRequest(req *http.Request) (*httpTypes.Request, *witTypes.FutureRe
 	if host == "" {
 		host = req.URL.Host
 	}
-	if r := res.SetAuthority(witTypes.Some(host)); r.IsErr() {
+	if res.SetAuthority(witTypes.Some(host)).IsErr() {
 		return nil, nil, nil, fmt.Errorf("invalid request authority %q", host)
 	}
-	if r := res.SetPathWithQuery(witTypes.Some(req.URL.RequestURI())); r.IsErr() {
+	if res.SetPathWithQuery(witTypes.Some(req.URL.RequestURI())).IsErr() {
 		return nil, nil, nil, fmt.Errorf("invalid request path %q", req.URL.RequestURI())
 	}
 

--- a/p3/net/wasihttp/request.go
+++ b/p3/net/wasihttp/request.go
@@ -17,6 +17,10 @@ func parseHttpRequest(req *http.Request) (*httpTypes.Request, *witTypes.FutureRe
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	// The Host header is carried by SetAuthority on the outgoing request.
+	// Forwarding it as a field can conflict with the authority used for TLS
+	// SNI and is rejected by some WASI HTTP implementations.
+	f.Delete("Host") //nolint:errcheck
 
 	trailerWriter, trailerReader := httpTypes.MakeFutureResultOptionFieldsErrorCode()
 	someBody := witTypes.None[*witTypes.StreamReader[uint8]]()
@@ -35,7 +39,15 @@ func parseHttpRequest(req *http.Request) (*httpTypes.Request, *witTypes.FutureRe
 
 	res.SetMethod(internalhttp.MapMethodToWasi(req.Method))
 	res.SetScheme(mapUrlScheme(req.URL))
-	res.SetAuthority(witTypes.Some(req.Host))
+	// req.Host may be empty on client requests; per net/http, the transport
+	// falls back to req.URL.Host in that case. The authority is also used by
+	// the WASI host for TLS SNI, so an empty value causes TLS handshake
+	// failures (certificate/hostname mismatch) against HTTPS endpoints.
+	host := req.Host
+	if host == "" {
+		host = req.URL.Host
+	}
+	res.SetAuthority(witTypes.Some(host))
 	res.SetPathWithQuery(witTypes.Some(req.URL.RequestURI()))
 
 	finish := func() {

--- a/p3/net/wasihttp/request.go
+++ b/p3/net/wasihttp/request.go
@@ -17,10 +17,6 @@ func parseHttpRequest(req *http.Request) (*httpTypes.Request, *witTypes.FutureRe
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	// The Host header is carried by SetAuthority on the outgoing request.
-	// Forwarding it as a field can conflict with the authority used for TLS
-	// SNI and is rejected by some WASI HTTP implementations.
-	f.Delete("Host") //nolint:errcheck
 
 	trailerWriter, trailerReader := httpTypes.MakeFutureResultOptionFieldsErrorCode()
 	someBody := witTypes.None[*witTypes.StreamReader[uint8]]()

--- a/p3/net/wasihttp/request.go
+++ b/p3/net/wasihttp/request.go
@@ -1,6 +1,7 @@
 package wasihttp
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 
@@ -33,16 +34,24 @@ func parseHttpRequest(req *http.Request) (*httpTypes.Request, *witTypes.FutureRe
 	opts := witTypes.None[*httpTypes.RequestOptions]()
 	res, futureRead := httpTypes.RequestNew(f, someBody, trailerReader, opts)
 
-	res.SetMethod(internalhttp.MapMethodToWasi(req.Method))
-	res.SetScheme(mapUrlScheme(req.URL))
+	if r := res.SetMethod(internalhttp.MapMethodToWasi(req.Method)); r.IsErr() {
+		return nil, nil, nil, fmt.Errorf("invalid request method %q", req.Method)
+	}
+	if r := res.SetScheme(mapUrlScheme(req.URL)); r.IsErr() {
+		return nil, nil, nil, fmt.Errorf("invalid request scheme %q", req.URL.Scheme)
+	}
 	// req.Host may be empty on client requests; fall back to req.URL.Host
 	// so the WASI host has a valid authority for TLS SNI.
 	host := req.Host
 	if host == "" {
 		host = req.URL.Host
 	}
-	res.SetAuthority(witTypes.Some(host))
-	res.SetPathWithQuery(witTypes.Some(req.URL.RequestURI()))
+	if r := res.SetAuthority(witTypes.Some(host)); r.IsErr() {
+		return nil, nil, nil, fmt.Errorf("invalid request authority %q", host)
+	}
+	if r := res.SetPathWithQuery(witTypes.Some(req.URL.RequestURI())); r.IsErr() {
+		return nil, nil, nil, fmt.Errorf("invalid request path %q", req.URL.RequestURI())
+	}
 
 	finish := func() {
 		if req.Body != nil {

--- a/p3/net/wasihttp/request.go
+++ b/p3/net/wasihttp/request.go
@@ -35,10 +35,8 @@ func parseHttpRequest(req *http.Request) (*httpTypes.Request, *witTypes.FutureRe
 
 	res.SetMethod(internalhttp.MapMethodToWasi(req.Method))
 	res.SetScheme(mapUrlScheme(req.URL))
-	// req.Host may be empty on client requests; per net/http, the transport
-	// falls back to req.URL.Host in that case. The authority is also used by
-	// the WASI host for TLS SNI, so an empty value causes TLS handshake
-	// failures (certificate/hostname mismatch) against HTTPS endpoints.
+	// req.Host may be empty on client requests; fall back to req.URL.Host
+	// so the WASI host has a valid authority for TLS SNI.
 	host := req.Host
 	if host == "" {
 		host = req.URL.Host

--- a/p3/net/wasihttp/response.go
+++ b/p3/net/wasihttp/response.go
@@ -31,5 +31,5 @@ func newResponseBodyTrailer(resp *httpTypes.Response) (io.ReadCloser, http.Heade
 	stream, trailersFut := httpTypes.ResponseConsumeBody(resp, read)
 
 	trailerMap := http.Header{}
-	return internalhttp.NewBodyReader(stream, trailersFut, fut, trailerMap), trailerMap
+	return internalhttp.NewBodyReader(stream, trailersFut, fut, trailerMap, mapErrorCode), trailerMap
 }


### PR DESCRIPTION
req.Host is not guaranteed to be set on client requests (net/http falls
back to req.URL.Host when it's empty). The WASI host uses the authority
field for TLS SNI, so an empty authority caused TLS handshake failures
(certificate/hostname mismatch) against HTTPS endpoints. Fall back to
req.URL.Host when req.Host is empty.

Also strip the Host header from the forwarded fields: it's carried
separately via SetAuthority, and duplicating it can conflict with the
authority used for SNI.