### PR TITLE
fix: create p3/vX.Y.Z tag for submodule on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,26 +1,57 @@
 name: Release Workflow
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+        type: string
 
 permissions:
   packages: write
 
 jobs:
-  build-examples:
-    name: Build Example - ${{ matrix.function }}
+  tag-root:
+    name: Tag Root Module
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Create root tag
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git tag "${{ inputs.version }}"
+          git push origin "${{ inputs.version }}"
+
+  tag-p3:
+    name: Tag p3 Submodule
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Create p3 tag
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git tag "p3/${{ inputs.version }}"
+          git push origin "p3/${{ inputs.version }}"
+
+  build-root-examples:
+    name: Build Root Example - ${{ matrix.function }}
+    runs-on: ubuntu-latest
+    needs: tag-root
     strategy:
       fail-fast: false
       matrix:
         function:
           - hello
-          - hello-p3
           - client
-          - client-p3
           - blobby
           - socket-client
           - socket-server
@@ -47,14 +78,47 @@ jobs:
       - name: Publish artifact
         working-directory: examples/${{ matrix.function }}
         run: |
-          tag=$(echo "${{ github.ref_name }}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+' && echo "${{ github.ref_name }}" || echo "canary")
-          wash oci push ghcr.io/${{ github.repository }}/${{ matrix.function }}:${tag} build/${{ matrix.function }}.wasm
+          wash oci push ghcr.io/${{ github.repository }}/${{ matrix.function }}:${{ inputs.version }} build/${{ matrix.function }}.wasm
+
+  build-p3-examples:
+    name: Build p3 Example - ${{ matrix.function }}
+    runs-on: ubuntu-latest
+    needs: tag-p3
+    strategy:
+      fail-fast: false
+      matrix:
+        function:
+          - hello-p3
+          - client-p3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install wash
+        uses: wasmCloud/setup-wash-action@main
+        with:
+          wash-version: wash-v2.0.0-rc.8
+      - name: Install componentize-go
+        uses: bytecodealliance/componentize-go/.github/actions/setup-componentize-go@main
+        with:
+          version: canary
+      - name: Run Build
+        working-directory: examples/${{ matrix.function }}
+        run: make build
+      - name: Login to container registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Publish artifact
+        working-directory: examples/${{ matrix.function }}
+        run: |
+          wash oci push ghcr.io/${{ github.repository }}/${{ matrix.function }}:${{ inputs.version }} build/${{ matrix.function }}.wasm
 
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: build-examples
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: [build-root-examples, build-p3-examples]
     permissions:
       contents: write
     steps:
@@ -64,12 +128,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${{ github.ref_name }}" --generate-notes
-      - name: Tag p3 submodule
-        run: |
-          version="${{ github.ref_name }}"
-          p3_tag="p3/${version}"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
-          git tag "${p3_tag}"
-          git push origin "${p3_tag}"
+          gh release create "${{ inputs.version }}" --generate-notes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,3 +65,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "${{ github.ref_name }}" --generate-notes
+      - name: Tag p3 submodule
+        run: |
+          version="${{ github.ref_name }}"
+          p3_tag="p3/${version}"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git tag "${p3_tag}"
+          git push origin "${p3_tag}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ permissions:
   packages: write
 
 jobs:
-  tag-root:
+  tag:
     name: Tag Root Module
     runs-on: ubuntu-latest
     permissions:
@@ -42,10 +42,10 @@ jobs:
           git tag "p3/${{ inputs.version }}"
           git push origin "p3/${{ inputs.version }}"
 
-  build-root-examples:
+  build-examples:
     name: Build Root Example - ${{ matrix.function }}
     runs-on: ubuntu-latest
-    needs: tag-root
+    needs: tag
     strategy:
       fail-fast: false
       matrix:
@@ -118,7 +118,7 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [build-root-examples, build-p3-examples]
+    needs: [build-examples, build-p3-examples]
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
The p3/ directory has its own go.mod, making it a separate Go module
(github.com/jamesstocktonj1/componentize-sdk/p3). The Go module proxy
requires tags in the format `p3/vX.Y.Z` to resolve versioned imports
of this submodule. Add a step in the release job to automatically push
a matching `p3/<version>` tag whenever a root `v*` release tag is created.

https://claude.ai/code/session_01DBHSYhKhafUMHYivjeHU8x