### PR TITLE
fix: tidy dependent go.mod files after pinning p3 version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,13 @@ jobs:
       - name: Pin p3 version in exports modules
         run: |
           go mod edit -require=github.com/${{ github.repository }}/p3@${{ steps.compute.outputs.tag }} p3/exports/http/go.mod
+      - name: Tidy modules depending on p3/exports/http
+        run: |
+          for mod in $(grep -rl "${{ github.repository }}/p3/exports/http" --include=go.mod .); do
+            dir=$(dirname "$mod")
+            [ "$dir" = "./p3/exports/http" ] && continue
+            (cd "$dir" && go mod tidy)
+          done
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
## Summary
- Bumping the `require` version in `p3/exports/http/go.mod` leaves the indirect `p3` requirement stale in every module that depends on it (`examples/hello-p3`, `examples/client-p3`, `examples/socket-client-p3`), even though a local `replace` directive is in effect for local builds.
- CI runs with `-mod=readonly`, which refuses to auto-fix that drift and fails the example builds with `updates to go.mod needed, disabled by -mod=readonly`.
- Added a release workflow step that runs `go mod tidy` on the affected dependent modules right after pinning, so the fix is included in the same release PR commit.

## Test plan
- [x] Reproduced locally: pinned `p3/exports/http/go.mod` to a fake tag, confirmed `go list ./... -mod=readonly` failed in `hello-p3`, `client-p3`, `socket-client-p3` (not `socket-server-p3`, which doesn't import `p3/exports/http`).
- [x] Applied the same `go mod tidy` logic added to the workflow and confirmed all four `-p3` examples pass `-mod=readonly` afterward.

This PR is stacked on `claude/release-workflow-go-mod-pr-u1ik6x` (#41) since it depends on the "Create Pull Request" step introduced there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWkQFMSJQ3Z9kmaAJzeQeq)_